### PR TITLE
Bug 1175082 - Properly build the boot image r=dhylands

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -11,32 +11,30 @@ LOCAL_MODULE_PATH  := $(TARGET_ROOT_OUT)/sbin
 LOCAL_MODULE_CLASS := EXECUTABLES
 LOCAL_SRC_FILES    := init.sh
 LOCAL_REQUIRED_MODULES := busybox init extract_elf_ramdisk
+include $(BUILD_PREBUILT)
 
 root_init      := $(TARGET_ROOT_OUT)/init
 root_init_real := $(TARGET_ROOT_OUT)/init.real
-sbin_init_sh   := $(LOCAL_MODULE_PATH)/$(LOCAL_MODULE)
 
-$(LOCAL_MODULE)-post: $(TARGET_ROOT_OUT)/init
 	# If /init is a file and not a symlink then rename it to /init.real
 	# and make /init be a symlink to /sbin/init.sh (which will execute
 	# /init.real, if appropriate.
-	echo "===== BEFORE ====="
-	ls -l $(TARGET_ROOT_OUT)
-	if [ ! -L $(root_init) ]; then \
+$(root_init_real): $(root_init)
+	$(hide) echo "===== BEFORE ====="
+	$(hide) ls -l $(TARGET_ROOT_OUT)
+	$(hide) if [ ! -L $(root_init) ]; then \
 	  echo "/init $(root_init) isn't a symlink"; \
 	  mv $(root_init) $(root_init_real); \
 	  ln -s sbin/init.sh $(root_init); \
 	else \
 	  echo "/init $(root_init) is already a symlink"; \
 	fi
-	echo "===== AFTER ====="
-	ls -l $(TARGET_ROOT_OUT)
-	rm -f $(TARGET_ROOT_OUT)/sbin/sh
-	ln -s busybox $(TARGET_ROOT_OUT)/sbin/sh
+	$(hide) echo "===== AFTER ====="
+	$(hide) ls -l $(TARGET_ROOT_OUT)
+	$(hide) rm -f $(TARGET_ROOT_OUT)/sbin/sh
+	$(hide) ln -s busybox $(TARGET_ROOT_OUT)/sbin/sh
 
-ALL_DEFAULT_INSTALLED_MODULES += $(LOCAL_MODULE)-post
-
-include $(BUILD_PREBUILT)
+ALL_DEFAULT_INSTALLED_MODULES += $(root_init_real)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE       := busybox

--- a/init.sh
+++ b/init.sh
@@ -79,7 +79,7 @@ if [ -s /dev/key-events ] || busybox grep -q warmboot=${warmboot_recovery} /proc
   # /system/bin to be in the PATH.
   busybox mkdir -p /system/bin
   for app in $(busybox --list); do
-    busybox ln -s /sbin/busybox /system/bin/sh
+    busybox ln -s /sbin/busybox /system/bin/$app
   done
   export _PATH=${_PATH}:/system/bin
 else


### PR DESCRIPTION
When building via "build.sh bootimage" with an emply /out the init.real
was not being created. Update the dependency to fix this. This fixes cases
where the device would only boot to recovery.
